### PR TITLE
removed homebuilder crowdin info

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,5 +2,3 @@ files:
   - source: /bundles/org.openhab.ui.dashboard/ESH-INF/i18n/dashboard.properties
     translation: >-
       /bundles/org.openhab.ui.dashboard/ESH-INF/i18n/dashboard_%two_letters_code%.properties
-  - source: /bundles/org.openhab.ui.homebuilder/web/i18n/en-UK.json
-    translation: /bundles/org.openhab.ui.homebuilder/web/i18n/%locale%.json


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>